### PR TITLE
Fix global checking in init

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ class MongoDBProvider extends SettingProvider {
 
 		// Load all settings
 		collection.find().forEach(doc => {
-			const guild = doc.guild !== '0' ? doc.guild : 'global';
+			const guild = doc.guild !== 0 ? doc.guild : 'global';
 			this.settings.set(guild, doc.settings);
 
 			// Guild is not global, and doesn't exist currently so lets skip it.


### PR DESCRIPTION
In the `init ` function it checks if the guild ID is the string 0, when it is stored as an integer 0 everywhere else. This causes lots of missing data when reading data from the global guild that is **not stored in memory**. (ie. after a restart)