### PR TITLE
Fixed destroy() function, return mongo client argument, update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save mongodb commando-provider-mongo@dev
 ```
 
 ## Usage
-Below is an example on how to use it with [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) (recommended). There are probably other mongodb clients whose are able to return a Db instance of MongoClient and you are free to use them. However I will not deliver any support if you use another client. 
+Below is an example on how to use it with [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) (recommended). There are probably other mongodb clients whose are able to return a Db instance of MongoClient and you are free to use them. However I will not deliver any support if you use another client.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
@@ -28,7 +28,7 @@ const MongoDBProvider = require('commando-provider-mongo');
 ...
 
 client.setProvider(
-	MongoClient.connect('mongodb://localhost:27017').then(client => new MongoDBProvider(client.db('abot')))
+	MongoClient.connect('mongodb://localhost:27017').then(client => new MongoDBProvider(client, 'abot'))
 ).catch(console.error);
 
 ...

--- a/index.js
+++ b/index.js
@@ -9,14 +9,15 @@ class MongoDBProvider extends SettingProvider {
 	/**
 	 * @param {Db} db - Database for the provider
 	 */
-	constructor(db) {
+	constructor(mongoClient, dbName) {
 		super();
 
 		/**
 		 * Database that will be used for storing/retrieving settings
 		 * @type {Db}
 		 */
-		this.db = db;
+		this.mongoClient = mongoClient;
+		this.db = mongoClient.db(dbName);
 
 		/**
 		 * Client that the provider is for (set once the client is ready, after using {@link CommandoClient#setProvider})
@@ -85,7 +86,7 @@ class MongoDBProvider extends SettingProvider {
 
 	async destroy() {
 		// Close database connection
-		this.db.close();
+		this.mongoClient.close();
 
 		// Remove all listeners from the client
 		for (const [event, listener] of this.listeners) this.client.removeListener(event, listener);


### PR DESCRIPTION
The old
```js
this.db.close();
```
no longer works with node-mongodb-native v3.1.8: `TypeError: this.db.close is not a function`

Changed to:
```js
this.mongoClient.close();
```