### PR TITLE
Updated to work with Discord.js v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class MongoDBProvider extends SettingProvider {
 			this.settings.set(guild, doc.settings);
 
 			// Guild is not global, and doesn't exist currently so lets skip it.
-			if (guild !== 'global' && !client.guilds.has(doc.guild)) return;
+			if (guild !== 'global' && !client.guilds.cache.has(doc.guild)) return;
 
 			this.setupGuild(guild, doc.settings);
 		});
@@ -71,14 +71,14 @@ class MongoDBProvider extends SettingProvider {
 			})
 			.set('commandRegister', command => {
 				for (const [guild, settings] of this.settings) {
-					if (guild !== 'global' && !client.guilds.has(guild)) continue;
-					this.setupGuildCommand(client.guilds.get(guild), command, settings);
+					if (guild !== 'global' && !client.guilds.cache.has(guild)) continue;
+					this.setupGuildCommand(client.guilds.cache.get(guild), command, settings);
 				}
 			})
 			.set('groupRegister', group => {
 				for (const [guild, settings] of this.settings) {
-					if (guild !== 'global' && !client.guilds.has(guild)) continue;
-					this.setupGuildGroup(client.guilds.get(guild), group, settings);
+					if (guild !== 'global' && !client.guilds.cache.has(guild)) continue;
+					this.setupGuildGroup(client.guilds.cache.get(guild), group, settings);
 				}
 			});
 		for (const [event, listener] of this.listeners) client.on(event, listener);
@@ -152,7 +152,7 @@ class MongoDBProvider extends SettingProvider {
 	 */
 	setupGuild(guild, settings) {
 		if (typeof guild !== 'string') throw new TypeError('The guild must be a guild ID or "global".');
-		guild = this.client.guilds.get(guild) || null;
+		guild = this.client.guilds.cache.get(guild) || null;
 
 		// Load the command prefix
 		if (typeof settings.prefix !== 'undefined') {

--- a/index.js
+++ b/index.js
@@ -7,17 +7,17 @@ const SettingProvider = require('discord.js-commando').SettingProvider;
 class MongoDBProvider extends SettingProvider {
 
 	/**
-	 * @param {Db} db - Database for the provider
+	 * @param {MongoClient} client - Database for the provider
+	 * @param {string} dbName - The database name
 	 */
-	constructor(mongoClient, dbName) {
+	constructor(client, dbName) {
 		super();
 
 		/**
 		 * Database that will be used for storing/retrieving settings
 		 * @type {Db}
 		 */
-		this.mongoClient = mongoClient;
-		this.db = mongoClient.db(dbName);
+		this.db = client.db(dbName);
 
 		/**
 		 * Client that the provider is for (set once the client is ready, after using {@link CommandoClient#setProvider})
@@ -44,20 +44,20 @@ class MongoDBProvider extends SettingProvider {
 
 	async init(client) {
 		this.client = client;
+        
+        // Load or create the settings collection
+        const collection = await this.db.collection('settings');
+        
+        // Load all settings
+        collection.find().forEach(doc => {
+            const guild = doc.guild !== '0' ? doc.guild : 'global';
+            this.settings.set(guild, doc.settings);
 
-		// Load or create the settings collection
-		const collection = await this.db.collection('settings');
+            // Guild is not global, and doesn't exist currently so lets skip it.
+            if(guild !== 'global' && !(client.guilds.cache.has(doc.guild) || client.guilds.has(doc.guild))) return;
 
-		// Load all settings
-		collection.find().forEach(doc => {
-			const guild = doc.guild !== 0 ? doc.guild : 'global';
-			this.settings.set(guild, doc.settings);
-
-			// Guild is not global, and doesn't exist currently so lets skip it.
-			if (guild !== 'global' && !client.guilds.cache.has(doc.guild)) return;
-
-			this.setupGuild(guild, doc.settings);
-		});
+            this.setupGuild(guild, doc.settings);
+        });
 
 		// Listen for changes
 		this.listeners
@@ -66,30 +66,30 @@ class MongoDBProvider extends SettingProvider {
 			.set('groupStatusChange', (guild, group, enabled) => this.set(guild, `grp-${group.id}`, enabled))
 			.set('guildCreate', guild => {
 				const settings = this.settings.get(guild.id);
-				if (!settings) return;
+				if(!settings) return;
 				this.setupGuild(guild.id, settings);
 			})
 			.set('commandRegister', command => {
-				for (const [guild, settings] of this.settings) {
-					if (guild !== 'global' && !client.guilds.cache.has(guild)) continue;
-					this.setupGuildCommand(client.guilds.cache.get(guild), command, settings);
+				for(const [guild, settings] of this.settings) {
+					if(guild !== 'global' && !(client.guilds.cache.has(guild) || client.guilds.has(guild))) continue;
+					this.setupGuildCommand((client.guilds.cache.get(guild) || client.guilds.get(guild)), command, settings);
 				}
 			})
 			.set('groupRegister', group => {
-				for (const [guild, settings] of this.settings) {
-					if (guild !== 'global' && !client.guilds.cache.has(guild)) continue;
-					this.setupGuildGroup(client.guilds.cache.get(guild), group, settings);
+				for(const [guild, settings] of this.settings) {
+					if(guild !== 'global' && !(client.guilds.cache.has(guild) || client.guilds.has(guild))) continue;
+					this.setupGuildGroup((client.guilds.cache.get(guild) || client.guilds.get(guild)), group, settings);
 				}
 			});
-		for (const [event, listener] of this.listeners) client.on(event, listener);
+		for(const [event, listener] of this.listeners) client.on(event, listener);
 	}
 
 	async destroy() {
 		// Close database connection
-		this.mongoClient.close();
+		this.db.close();
 
 		// Remove all listeners from the client
-		for (const [event, listener] of this.listeners) this.client.removeListener(event, listener);
+		for(const [event, listener] of this.listeners) this.client.removeListener(event, listener);
 		this.listeners.clear();
 	}
 
@@ -101,48 +101,48 @@ class MongoDBProvider extends SettingProvider {
 	async set(guild, key, val) {
 		guild = this.constructor.getGuildID(guild);
 		let settings = this.settings.get(guild);
-		if (!settings) {
+		if(!settings) {
 			settings = {};
 			this.settings.set(guild, settings);
 		}
 
-		settings[key] = val;
+        settings[key] = val;
+        
+        await this.updateGuild(guild, settings);
 
-		await this.updateGuild(guild, settings);
-
-		if (guild === 'global') this.updateOtherShards(key, val);
+		if(guild === 'global') this.updateOtherShards(key, val);
 		return val;
 	}
 
 	async remove(guild, key) {
 		guild = this.constructor.getGuildID(guild);
 		const settings = this.settings.get(guild);
-		if (!settings || typeof settings[key] === 'undefined') return;
+		if(!settings || typeof settings[key] === 'undefined') return;
 
 		const val = settings[key];
-		delete settings[key]; // NOTE: I know this isn't efficient, but it does the job.
+        delete settings[key]; // NOTE: I know this isn't efficient, but it does the job.
 
-		await this.updateGuild(guild, settings);
+        await this.updateGuild(guild, settings);
 
-		if (guild === 'global') this.updateOtherShards(key, undefined);
+		if(guild === 'global') this.updateOtherShards(key, undefined);
 		return val;
 	}
 
 	async clear(guild) {
 		guild = this.constructor.getGuildID(guild);
-		if (!this.settings.has(guild)) return;
-		this.settings.delete(guild);
+		if(!this.settings.has(guild)) return;
+        this.settings.delete(guild);
+        
+        const collection = await this.db.collection('settings');
+        return collection.deleteOne({ guild: guild !== 'global' ? guild : 0 });
+    }
+    
+    async updateGuild(guild, settings) {
+        guild = guild !== 'global' ? guild : 0;
 
-		const collection = await this.db.collection('settings');
-		return collection.deleteOne({ guild: guild !== 'global' ? guild : 0 });
-	}
-
-	async updateGuild(guild, settings) {
-		guild = guild !== 'global' ? guild : 0;
-
-		const collection = await this.db.collection('settings');
-		return collection.updateOne({ guild }, { $set: { guild, settings } }, { upsert: true });
-	}
+        const collection = await this.db.collection('settings');
+        return collection.updateOne({ guild }, { $set: { guild, settings } }, { upsert: true });
+    }
 
 	/**
 	 * Loads all settings for a guild
@@ -151,18 +151,18 @@ class MongoDBProvider extends SettingProvider {
 	 * @private
 	 */
 	setupGuild(guild, settings) {
-		if (typeof guild !== 'string') throw new TypeError('The guild must be a guild ID or "global".');
-		guild = this.client.guilds.cache.get(guild) || null;
+		if(typeof guild !== 'string') throw new TypeError('The guild must be a guild ID or "global".');
+		guild = (this.client.guilds.cache.get(guild) || this.client.guilds.get(guild)) || null;
 
 		// Load the command prefix
-		if (typeof settings.prefix !== 'undefined') {
-			if (guild) guild._commandPrefix = settings.prefix;
+		if(typeof settings.prefix !== 'undefined') {
+			if(guild) guild._commandPrefix = settings.prefix;
 			else this.client._commandPrefix = settings.prefix;
 		}
 
 		// Load all command/group statuses
-		for (const command of this.client.registry.commands.values()) this.setupGuildCommand(guild, command, settings);
-		for (const group of this.client.registry.groups.values()) this.setupGuildGroup(guild, group, settings);
+		for(const command of this.client.registry.commands.values()) this.setupGuildCommand(guild, command, settings);
+		for(const group of this.client.registry.groups.values()) this.setupGuildGroup(guild, group, settings);
 	}
 
 	/**
@@ -173,9 +173,9 @@ class MongoDBProvider extends SettingProvider {
 	 * @private
 	 */
 	setupGuildCommand(guild, command, settings) {
-		if (typeof settings[`cmd-${command.name}`] === 'undefined') return;
-		if (guild) {
-			if (!guild._commandsEnabled) guild._commandsEnabled = {};
+		if(typeof settings[`cmd-${command.name}`] === 'undefined') return;
+		if(guild) {
+			if(!guild._commandsEnabled) guild._commandsEnabled = {};
 			guild._commandsEnabled[command.name] = settings[`cmd-${command.name}`];
 		} else {
 			command._globalEnabled = settings[`cmd-${command.name}`];
@@ -190,9 +190,9 @@ class MongoDBProvider extends SettingProvider {
 	 * @private
 	 */
 	setupGuildGroup(guild, group, settings) {
-		if (typeof settings[`grp-${group.id}`] === 'undefined') return;
-		if (guild) {
-			if (!guild._groupsEnabled) guild._groupsEnabled = {};
+		if(typeof settings[`grp-${group.id}`] === 'undefined') return;
+		if(guild) {
+			if(!guild._groupsEnabled) guild._groupsEnabled = {};
 			guild._groupsEnabled[group.id] = settings[`grp-${group.id}`];
 		} else {
 			group._globalEnabled = settings[`grp-${group.id}`];
@@ -206,7 +206,7 @@ class MongoDBProvider extends SettingProvider {
 	 * @private
 	 */
 	updateOtherShards(key, val) {
-		if (!this.client.shard) return;
+		if(!this.client.shard) return;
 		key = JSON.stringify(key);
 		val = typeof val !== 'undefined' ? JSON.stringify(val) : 'undefined';
 		this.client.shard.broadcastEval(`


### PR DESCRIPTION
discord.js v12 added '.cache'  to its naming conventions

```js
// example
!client.guilds.has()
// becomes
!client.guilds.cache.has()
```

closes #4 && closes #5 